### PR TITLE
Fixing bug where method member could not be found, because one of the…

### DIFF
--- a/TestTools/TestTools/Structure/MemberTranslators/AlternateNameMemberTranslator.cs
+++ b/TestTools/TestTools/Structure/MemberTranslators/AlternateNameMemberTranslator.cs
@@ -30,7 +30,7 @@ namespace TestTools.Structure
             {
                 foreach (var methodBase2 in members.OfType<MethodBase>())
                 {
-                    var parameterTypes1 = methodBase1.GetParameters().Select(p => p.ParameterType);
+                    var parameterTypes1 = methodBase1.GetParameters().Select(p => Service.TranslateType(p.ParameterType));
                     var parameterTypes2 = methodBase2.GetParameters().Select(p => p.ParameterType);
 
                     if (parameterTypes1.SequenceEqual(parameterTypes2))

--- a/TestTools/TestTools/Structure/MemberTranslators/IMemberTranslator.cs
+++ b/TestTools/TestTools/Structure/MemberTranslators/IMemberTranslator.cs
@@ -8,6 +8,7 @@ namespace TestTools.Structure
     public interface IMemberTranslator
     {
         Type TargetType { get; set; }
+        IStructureService Service { get; set; }
         StructureVerifier Verifier { get; set; }
         MemberInfo Translate(MemberInfo member);
     }

--- a/TestTools/TestTools/Structure/MemberTranslators/MemberTranslator.cs
+++ b/TestTools/TestTools/Structure/MemberTranslators/MemberTranslator.cs
@@ -11,6 +11,8 @@ namespace TestTools.Structure
 
         public StructureVerifier Verifier { get; set; }
 
+        public IStructureService Service { get; set; }
+
         public abstract MemberInfo Translate(MemberInfo member);
     }
 }

--- a/TestTools/TestTools/Structure/MemberTranslators/SameNameMemberTranslator.cs
+++ b/TestTools/TestTools/Structure/MemberTranslators/SameNameMemberTranslator.cs
@@ -27,7 +27,7 @@ namespace TestTools.Structure
                     if (methodBase2.IsGenericMethod && !methodBase2.IsConstructedGenericMethod)
                         methodBase3 = ((MethodInfo)methodBase2).MakeGenericMethod(methodBase1.GetGenericArguments());
 
-                    var parameterTypes1 = methodBase1.GetParameters().Select(p => p.ParameterType);
+                    var parameterTypes1 = methodBase1.GetParameters().Select(p => Service.TranslateType(p.ParameterType));
                     var parameterTypes2 = methodBase3.GetParameters().Select(p => p.ParameterType);
 
                     if (parameterTypes1.SequenceEqual(parameterTypes2))

--- a/TestTools/TestTools/Structure/StructureService.cs
+++ b/TestTools/TestTools/Structure/StructureService.cs
@@ -96,6 +96,7 @@ namespace TestTools.Structure
             
             IMemberTranslator translator = memberInfo.GetCustomTranslator() ?? MemberTranslator;
 
+            translator.Service = this;
             translator.Verifier = StructureVerifier;
             translator.TargetType = TranslateType(memberInfo.DeclaringType);
 
@@ -109,6 +110,7 @@ namespace TestTools.Structure
 
             IMemberTranslator translator = memberInfo.GetCustomTranslator() ?? MemberTranslator;
 
+            translator.Service = this;
             translator.Verifier = StructureVerifier;
             translator.TargetType = targetType;
 


### PR DESCRIPTION
… parameters was a translatable type. This bug is resolved by adding a reference to StructureService to MemberTranslator, so it can translate parameter types.